### PR TITLE
Fixed typo in index.js 13th line

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ try {
 } catch(e) {}
 
 /**
- * @param {stirng} moduleName module name
+ * @param {string} moduleName module name
  */
 function load(moduleName) {
     try {


### PR DESCRIPTION
It was previously stirng. Its now fixed to string