### PR TITLE
feat: add unified fontSize

### DIFF
--- a/src/Rank.ts
+++ b/src/Rank.ts
@@ -67,7 +67,7 @@ class Rank {
 
     /**
      * Creates Rank card
-     * @example 
+     * @example
      * const rank = new canvacord.Rank()
             .setAvatar(img)
             .setCurrentXP(203)
@@ -76,7 +76,7 @@ class Rank {
             .setProgressBar(["#FF0000", "#0000FF"], "GRADIENT")
             .setUsername("Snowflake")
             .setDiscriminator("0007");
-        
+
         rank.build()
             .then(data => {
                 canvacord.write(data, "RankCard.png");
@@ -196,7 +196,7 @@ class Rank {
 
     /**
      * If it should render username with emojis (if any)
-     * @param {boolean} [apply=false] Set it to `true` to render emojis. 
+     * @param {boolean} [apply=false] Set it to `true` to render emojis.
      * @returns {Rank}
      */
     renderEmojis(apply = false) {
@@ -294,6 +294,15 @@ class Rank {
         if (typeof data !== "number") throw new Error(`Required xp data type must be a number, received ${typeof data}!`);
         this.data.requiredXP.data = data;
         this.data.requiredXP.color = color && typeof color === "string" ? color : "#FFFFFF";
+        return this;
+    }
+
+    /**
+     * Set font size
+     * @param {number} size
+     */
+    setFontSize(size: number) {
+        this.data.fontSize = size;
         return this;
     }
 
@@ -497,7 +506,7 @@ class Rank {
         ctx.globalAlpha = 1;
 
         // draw username
-        ctx.font = `bold 36px ${ops.fontX}`;
+        ctx.font = `bold ${this.data.fontSize ?? '36px'} ${ops.fontX}`;
         ctx.fillStyle = this.data.username.color;
         ctx.textAlign = "start";
         const name = Util.shorten(this.data.username.name, 10);
@@ -509,19 +518,19 @@ class Rank {
         if (!this.data.discriminator.discrim) throw new Error("Missing discriminator!");
         const discrim = `${this.data.discriminator.discrim}`;
         if (discrim) {
-            ctx.font = `36px ${ops.fontY}`;
+            ctx.font = `${this.data.fontSize ?? '36px'} ${ops.fontY}`;
             ctx.fillStyle = this.data.discriminator.color;
-            ctx.textAlign = "center";
+            ctx.textAlign = "start";
             ctx.fillText(`#${discrim.substr(0, 4)}`, ctx.measureText(name).width + 20 + 335, 164);
         }
 
         // fill level
         if (this.data.level.display && !isNaN(this.data.level.data)) {
-            ctx.font = `bold 36px ${ops.fontX}`;
+            ctx.font = `bold ${this.data.fontSize ?? '36px'} ${ops.fontX}`;
             ctx.fillStyle = this.data.level.textColor;
             ctx.fillText(this.data.level.displayText, 800 - ctx.measureText(Util.toAbbrev(parseInt(this.data.level.data))).width, 82);
 
-            ctx.font = `bold 32px ${ops.fontX}`;
+            ctx.font = `bold ${this.data.fontSize ?? '32px'} ${ops.fontX}`;
             ctx.fillStyle = this.data.level.color;
             ctx.textAlign = "end";
             ctx.fillText(Util.toAbbrev(parseInt(this.data.level.data)), 860, 82);
@@ -529,22 +538,22 @@ class Rank {
 
         // fill rank
         if (this.data.rank.display && !isNaN(this.data.rank.data)) {
-            ctx.font = `bold 36px ${ops.fontX}`;
+            ctx.font = `bold ${this.data.fontSize ?? '36px'} ${ops.fontX}`;
             ctx.fillStyle = this.data.rank.textColor;
             ctx.fillText(this.data.rank.displayText, 800 - ctx.measureText(Util.toAbbrev(parseInt(this.data.level.data)) || "-").width - 7 - ctx.measureText(this.data.level.displayText).width - 7 - ctx.measureText(Util.toAbbrev(parseInt(this.data.rank.data)) || "-").width, 82);
 
-            ctx.font = `bold 32px ${ops.fontX}`;
+            ctx.font = `bold ${this.data.fontSize ?? '32px'} ${ops.fontX}`;
             ctx.fillStyle = this.data.rank.color;
             ctx.textAlign = "end";
             ctx.fillText(Util.toAbbrev(parseInt(this.data.rank.data)), 790 - ctx.measureText(Util.toAbbrev(parseInt(this.data.level.data)) || "-").width - 7 - ctx.measureText(this.data.level.displayText).width, 82);
         }
 
         // show progress
-        ctx.font = `bold 30px ${ops.fontX}`;
+        ctx.font = `bold ${this.data.fontSize ?? '30px'} ${ops.fontX}`;
         ctx.fillStyle = this.data.requiredXP.color;
         ctx.textAlign = "start";
         ctx.fillText("/ " + Util.toAbbrev(this.data.requiredXP.data), 670 + ctx.measureText(Util.toAbbrev(this.data.currentXP.data)).width + 15, 164);
-        
+
         ctx.fillStyle = this.data.currentXP.color;
         ctx.fillText(Util.toAbbrev(this.data.currentXP.data), 670, 164);
 


### PR DESCRIPTION
I personally like using the same fontSize across all of the elements.
I could add more methods for each element so `setRankFontSize()` and `setProgressBarFontSize()` if need be.

The should fallback back to the original values if not provided.