### PR TITLE
fix: ensure build is run even on git installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "docs": "docgen --source src --custom docs/index.yml --output docs/docs.json",
     "docs:test": "docgen --source src --custom docs/index.yml",
     "build": "npx tsup --external discord-canvas --format esm,cjs --legacy-output --dts ./index.ts",
-    "test": "cd test && node ."
+    "test": "cd test && node .",
+    "prepare": "npm run build"
   },
   "types": "./dist/index.d.ts",
   "repository": {


### PR DESCRIPTION
This should fix an empty `dist` when installing via `npm i github:DevSnowflake/canvacord#develop`.