### PR TITLE
Update/fixing a typo

### DIFF
--- a/src/Canvacord.js
+++ b/src/Canvacord.js
@@ -969,7 +969,7 @@ class Canvacord {
      * @returns {Promise<Buffer>}
      */
     static async clyde(message) {
-        if (!message) messgae = "Please provide text!";
+        if (!message) message = "Please provide text!";
         await this.__wait()
         let avatar = await Canvas.loadImage(await Canvacord.circle(Canvacord.assets("IMAGE").CLYDE));
         let badge = await Canvas.loadImage(Canvacord.assets("IMAGE").BOTBADGE);


### PR DESCRIPTION
Fixed "messgae" to "message" which was causing an error when no text was provided